### PR TITLE
Script is using bash only syntax. Fixing declaration.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SOURCE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
Line 3 of the Shell script is using bash syntax. This works fine with /bin/sh on systems that symlink sh to bash but fails on systems line alpine where bash is not natively the standard shell but sh really is sh.