### PR TITLE
Rename display_error to libcaesium_display_error for the sake of name overlapping

### DIFF
--- a/caesium/caesium.c
+++ b/caesium/caesium.c
@@ -13,7 +13,7 @@ bool cs_compress(const char *input_path, const char *output_path, cs_image_pars 
 	int compression_step_result;
 
 	if ((pInputFile = fopen(input_path, "rb")) == NULL) {
-		display_error(ERROR, 104);
+		libcaesium_display_error(ERROR, 104);
         *err_n = error_code;
 		return result;
 	}
@@ -23,7 +23,7 @@ bool cs_compress(const char *input_path, const char *output_path, cs_image_pars 
 	fclose(pInputFile);
 
 	if (type == UNKN) {
-		display_error(WARNING, 103);
+		libcaesium_display_error(WARNING, 103);
 	} else if (type == CS_JPEG) {
 		if (options->jpeg.quality != 0) {
 			compression_step_result = cs_jpeg_compress(output_path, cs_jpeg_decompress(input_path, &options->jpeg), &options->jpeg);

--- a/caesium/error.c
+++ b/caesium/error.c
@@ -5,7 +5,7 @@
 
 int error_code = 0;
 
-void display_error(error_level level, int code) {
+void libcaesium_display_error(error_level level, int code) {
     error_code = code;
     if (VERBOSE) {
         char *error_level = ((level) ? "[WARNING]" : "[ERROR]");

--- a/caesium/error.h
+++ b/caesium/error.h
@@ -5,7 +5,7 @@
 
 extern int error_code;
 
-void display_error(error_level level, int code);
+void libcaesium_display_error(error_level level, int code);
 
 const char *get_error_message(int code);
 

--- a/caesium/jpeg.c
+++ b/caesium/jpeg.c
@@ -23,7 +23,7 @@ struct jpeg_decompress_struct cs_get_markers(const char *input)
 
 	//Check for errors
 	if ((fp = fopen(input, "rb")) == NULL) {
-		display_error(ERROR, 200);
+		libcaesium_display_error(ERROR, 200);
 	}
 
 	//Create the IO instance for the input file
@@ -71,7 +71,7 @@ bool cs_jpeg_optimize(const char *input_file, const char *output_file, cs_jpeg_p
 
 	//Check for errors
 	if ((fp = fopen(input_file, "rb")) == NULL) {
-		display_error(ERROR, 201);
+		libcaesium_display_error(ERROR, 201);
 	}
 
 	//Create the IO instance for the input file
@@ -103,7 +103,7 @@ bool cs_jpeg_optimize(const char *input_file, const char *output_file, cs_jpeg_p
 
 	//Check for errors
 	if ((fp = fopen(output_file, "wb")) == NULL) {
-		display_error(ERROR, 202);
+		libcaesium_display_error(ERROR, 202);
 	}
 
 	//CRITICAL - This is the optimization step
@@ -153,7 +153,7 @@ int cs_jpeg_compress(const char *output_file, unsigned char *image_buffer, cs_jp
 
 	//Check for errors
 	if ((fp = fopen(output_file, "wb")) == NULL) {
-		display_error(ERROR, 203);
+		libcaesium_display_error(ERROR, 203);
 	}
 
 	tjCompressHandle = tjInitCompress();
@@ -170,7 +170,7 @@ int cs_jpeg_compress(const char *output_file, unsigned char *image_buffer, cs_jp
 				options->quality,
 				options->dct_method);
 	if (result == -1) {
-		display_error(ERROR, 207);
+		libcaesium_display_error(ERROR, 207);
 	} else {
 		fwrite(output_buffer, output_size, 1, fp);
 	}
@@ -192,15 +192,15 @@ unsigned char *cs_jpeg_decompress(const char *fileName, cs_jpeg_pars *options)
 	int fileWidth = 0, fileHeight = 0, jpegSubsamp = 0, colorSpace = 0, result = 0;
 
 	if ((fp = fopen(fileName, "rb")) == NULL) {
-		display_error(ERROR, 204);
+		libcaesium_display_error(ERROR, 204);
 	}
 	fseek(fp, 0, SEEK_END);
 	sourceJpegBufferSize = ftell(fp);
 	if (sourceJpegBufferSize == -1) {
-		display_error(ERROR, 205);
+		libcaesium_display_error(ERROR, 205);
 	}
 	if (sourceJpegBufferSize > INT_MAX) {
-		display_error(ERROR, 206);
+		libcaesium_display_error(ERROR, 206);
 	}
 	sourceJpegBuffer = tjAlloc((int) sourceJpegBufferSize);
 
@@ -211,7 +211,7 @@ unsigned char *cs_jpeg_decompress(const char *fileName, cs_jpeg_pars *options)
 						&jpegSubsamp, &colorSpace);
 
 	if (colorSpace == 4) { //CMYK
-		display_error(WARNING, 209);
+		libcaesium_display_error(WARNING, 209);
 		return 0;
 	}
 
@@ -233,7 +233,7 @@ unsigned char *cs_jpeg_decompress(const char *fileName, cs_jpeg_pars *options)
 				  colorSpace,
 				  options->dct_method);
 	if (result == -1) {
-		display_error(ERROR, 208);
+		libcaesium_display_error(ERROR, 208);
 	}
 
 	fclose(fp);

--- a/caesium/png.c
+++ b/caesium/png.c
@@ -23,11 +23,11 @@ bool cs_png_optimize(const char *input, const char *output, cs_png_pars *options
 	if (options->scale_factor > 0.0 && options->scale_factor < 1.0) {
 		result = cs_png_resize(input, output, options->scale_factor);
 		if (!result) {
-			display_error(ERROR, 304);
+			libcaesium_display_error(ERROR, 304);
 			return result;
 		}
 	} else if (options->scale_factor != 1.0) {
-		display_error(ERROR, 305);
+		libcaesium_display_error(ERROR, 305);
 		return false;
 	}
 
@@ -76,7 +76,7 @@ bool cs_png_optimize(const char *input, const char *output, cs_png_pars *options
 	free(orig_buffer);
 	free(resultpng);
 	if (error_code != 0) {
-		display_error(ERROR, error_code);
+		libcaesium_display_error(ERROR, error_code);
 	}
 	return result;
 }

--- a/caesium/utils.c
+++ b/caesium/utils.c
@@ -9,7 +9,7 @@ image_type detect_image_type(FILE *pFile)
 	unsigned char buffer[2];
 
 	if (pFile == NULL) {
-		display_error(WARNING, 101);
+		libcaesium_display_error(WARNING, 101);
 		return UNKN;
 	}
 


### PR DESCRIPTION
The name `display_error` is very common and may be overlapped by programs linking to this library, and thus introduce unexpected behaviour. E.g. caesium-clt has also a `display_error`, then when libcaesium calls  `display_error`, the one from caesium-clt was called.

There are also other solutions,

1. Using compiler/linker-specific options
For example, with the GCC extension, `__attribute__ ((visibility ("hidden")))` hides the function. Alternatively it is possible to pass a list of functions to be exported.  See also: https://developer.ibm.com/articles/au-aix-symbol-visibility/

However, this fashion is compiler/linker-specific, so that will lead to nightmare maintenance troubles. One thousand configuration for one thousand compilers.

2. Code amalgamation. This technique is used by sqlite, where 100+ source files were merged into a single 7.5MB 220,000+ LOC `sqlite3.c` by script, then symbols not desired to be exported can just be marked `static`. See also: https://www.sqlite.org/amalgamation.html

I believe this may be the best option, however I am too lazy for it. :)