### PR TITLE
feat(error): impl `Error` from `std` for `CaesiumError`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,3 +13,5 @@ impl fmt::Display for CaesiumError {
         write!(f, "{} [{}]", self.message, self.code)
     }
 }
+
+impl std::error::Error for CaesiumError {}


### PR DESCRIPTION
Had an issue when adding `CaesiumError` to `thiserror` because it did not implement 
`std::error::Error` : <https://github.com/dtolnay/thiserror/issues/118>