### PR TITLE
Make sure that r,g,b=0 if a=0 on lossy png compr.

### DIFF
--- a/src/png.rs
+++ b/src/png.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU8;
 
 use image::ImageFormat;
 use oxipng::Deflaters::Zopfli;
-
+use imagequant::RGBA;
 use crate::error::CaesiumError;
 use crate::resize::resize;
 use crate::CSParameters;
@@ -85,6 +85,14 @@ fn lossy(in_file: Vec<u8>, parameters: &CSParameters) -> Result<Vec<u8>, Caesium
         message: e.to_string(),
         code: 20208,
     })?;
+     
+    let palette = palette.iter()
+    .map(|px| if px.a == 0 {
+        RGBA { r: 0, g: 0, b: 0, a: 0 }
+    } else {
+        *px
+    }).collect::<Vec<RGBA>>();
+
 
     let mut encoder = lodepng::Encoder::new();
     encoder.set_palette(palette.as_slice()).map_err(|e| CaesiumError {


### PR DESCRIPTION
This is a pretty rare problem, but it happened to me, here is where it occurs:

In Spine 2D(https://esotericsoftware.com/) if you want to fade in / out / put a glow effect, you have to change shader color on all channels, instead of only alpha:

spine->setColor(vec4(1));         // fade in
spine->setColor(vec4(0.5));      // half-fade in
spine->setColor(vec4(0));         // transparent

Otherwise it looks bad (weird artefacts). Now, when I compress a png with lossy compression, sometimes the palette 
does not have a color to represent a transparent black (all zeroes), and puts some garbage value in it:

![image](https://github.com/user-attachments/assets/0e6dbda9-5ee6-4a7d-a7bf-4b5631404e93) - these should be all zeroes (they were before the compression)

This compression result spawns weird squares of unspecified color when I want to setColor to spines.

I propose:
 - If there exists a palette color with a == 0, just set other channels to zero. This fixes it.